### PR TITLE
allow to turn off the operator light that indicates the tally is woking

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Upcoming
+
+* [ADDED] the dim green light for the operator, that indicates the tally is working, can be turned off #50
+
 # v0.4.0
 
 **IMPORTANT**: Code on the Tally **HAS** changed. Tallies and the Hub will not be able to communicate

--- a/hub/cypress/integration/configTally.spec.ts
+++ b/hub/cypress/integration/configTally.spec.ts
@@ -20,6 +20,7 @@ describe('Check Default Tally Configuration', () => {
     cy.getTestId("tally-defaults-oc-yellow-pink").click()
     cy.getTestId("tally-defaults-sc-yellow-pink").click()
     cy.getTestId("tally-defaults-sp").click()
+    cy.getTestId("tally-defaults-oi").click()
     cy.getTestId("tally-defaults-submit").click()
 
     cy.reload().then(() => {
@@ -28,6 +29,7 @@ describe('Check Default Tally Configuration', () => {
       cy.getTestId("tally-defaults-oc").should('have.attr', 'data-value', 'yellow-pink')
       cy.getTestId("tally-defaults-sc").should('have.attr', 'data-value', 'yellow-pink')
       cy.getTestId("tally-defaults-sp").should('have.attr', 'data-value', 'false')
+      cy.getTestId("tally-defaults-oi").should('have.attr', 'data-value', 'false')
     })
   })
 
@@ -50,6 +52,7 @@ describe('Check Default Tally Configuration', () => {
     cy.getTestId("tally-defaults-oc").should('have.attr', 'data-value', 'default')
     cy.getTestId("tally-defaults-sc").should('have.attr', 'data-value', 'default')
     cy.getTestId("tally-defaults-sp").should('have.attr', 'data-value', 'true')
+    cy.getTestId("tally-defaults-oi").should('have.attr', 'data-value', 'true')
     validateSliderValue("*[data-testid=tally-defaults-ob]", 100)
     validateSliderValue("*[data-testid=tally-defaults-sb]", 100).then(() => {
       // change settings from server
@@ -58,6 +61,7 @@ describe('Check Default Tally Configuration', () => {
       config.setOperatorColorScheme("yellow-pink")
       config.setStageColorScheme("default")
       config.setStageShowsPreview(false)
+      config.setOperatorShowsIdle(false)
       socket.emit('config.change.tallyconfig', config.toJson())
 
       cy.getTestId("tally-defaults-oc").should('have.attr', 'data-value', 'yellow-pink')
@@ -68,6 +72,7 @@ describe('Check Default Tally Configuration', () => {
         cy.getTestId("tally-defaults-oc-default").click()
         cy.getTestId("tally-defaults-sc-default").click()
         cy.getTestId("tally-defaults-sp").click()
+        cy.getTestId("tally-defaults-oi").click()
         setSliderValue("*[data-testid=tally-defaults-ob]", 80)
         setSliderValue("*[data-testid=tally-defaults-sb]", 70).then(() => {
           // ... then change settings from server again
@@ -76,11 +81,13 @@ describe('Check Default Tally Configuration', () => {
           config.setOperatorColorScheme("yellow-pink")
           config.setStageColorScheme("yellow-pink")
           config.setStageShowsPreview(false)
+          config.setOperatorShowsIdle(false)
           socket.emit('config.change.tallyconfig', config.toJson())
 
           cy.getTestId("tally-defaults-oc").should('have.attr', 'data-value', 'yellow-pink')
           cy.getTestId("tally-defaults-sc").should('have.attr', 'data-value', 'yellow-pink')
           cy.getTestId("tally-defaults-sp").should('have.attr', 'data-value', 'false')
+          cy.getTestId("tally-defaults-oi").should('have.attr', 'data-value', 'false')
           validateSliderValue("*[data-testid=tally-defaults-ob]", 75)
           validateSliderValue("*[data-testid=tally-defaults-sb]", 75)
         })

--- a/hub/cypress/integration/tally-settings.spec.ts
+++ b/hub/cypress/integration/tally-settings.spec.ts
@@ -44,6 +44,7 @@ describe('Tally Settings', () => {
     cy.getTestId("tally-settings-oc").should('exist')
     cy.getTestId("tally-settings-sc").should('not.exist')
     cy.getTestId("tally-settings-sp").should('not.exist')
+    cy.getTestId("tally-settings-oi").should('exist')
   })
 
   it('can open settings for an udp tally', () => {
@@ -60,6 +61,7 @@ describe('Tally Settings', () => {
     cy.getTestId("tally-settings-oc").should('exist')
     cy.getTestId("tally-settings-sc").should('exist')
     cy.getTestId("tally-settings-sp").should('exist')
+    cy.getTestId("tally-settings-oi").should('exist')
   })
 
   it('can edit and save settings for an udp tally', () => {
@@ -89,10 +91,14 @@ describe('Tally Settings', () => {
     cy.getTestId("tally-settings-sp-toggle")
       .should('have.attr', 'data-selected', 'true')
       .click()
+    cy.getTestId("tally-settings-oi-toggle")
+      .should('have.attr', 'data-selected', 'true')
+      .click()
     // and it should show the default
     cy.getTestId("tally-settings-oc").should('have.attr', 'data-value', 'default')
     cy.getTestId("tally-settings-sc").should('have.attr', 'data-value', 'default')
     cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'true')
+    cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'true')
     validateSliderValue("*[data-testid=tally-settings-ob]", 100)
     validateSliderValue("*[data-testid=tally-settings-sb]", 100).then(() => {
       // and when we change values
@@ -101,6 +107,7 @@ describe('Tally Settings', () => {
       cy.getTestId("tally-settings-oc-default").click()
       cy.getTestId("tally-settings-sc-yellow-pink").click()
       cy.getTestId("tally-settings-sp").click()
+      cy.getTestId("tally-settings-oi").click()
     }).then(() => {
       // and save
       cy.getTestId(`tally-settings-submit`).click()
@@ -126,6 +133,9 @@ describe('Tally Settings', () => {
 
       cy.getTestId("tally-settings-sp-toggle").should('have.attr', 'data-selected', 'false')
       cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'false')
+
+      cy.getTestId("tally-settings-oi-toggle").should('have.attr', 'data-selected', 'false')
+      cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'false')
     })
   })
 
@@ -138,6 +148,7 @@ describe('Tally Settings', () => {
     initialConfig.setOperatorColorScheme("yellow-pink")
     initialConfig.setStageColorScheme("default")
     initialConfig.setStageShowsPreview(false)
+    initialConfig.setOperatorShowsIdle(false)
     
     cy.getTestId(`tally-${name}`).contains(name).then(() => {
       socket.emit('tally.settings', name, "udp", initialConfig.toJson())
@@ -169,12 +180,16 @@ describe('Tally Settings', () => {
       cy.getTestId("tally-settings-sp-toggle")
         .should('have.attr', 'data-selected', 'false')
         .click()
+      cy.getTestId("tally-settings-oi-toggle")
+        .should('have.attr', 'data-selected', 'false')
+        .click()
       // it should show the default value
       validateSliderValue("*[data-testid=tally-settings-ob]", 100)
       validateSliderValue("*[data-testid=tally-settings-sb]", 100)
       cy.getTestId("tally-settings-oc").should('have.attr', 'data-value', 'yellow-pink')
       cy.getTestId("tally-settings-sc").should('have.attr', 'data-value', 'default')
       cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'true')
+      cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'true')
 
     }).then(() => {
       // when we save
@@ -197,6 +212,8 @@ describe('Tally Settings', () => {
       cy.getTestId("tally-settings-oc").should('have.attr', 'data-value', 'default')
       cy.getTestId("tally-settings-sp-toggle").should('have.attr', 'data-selected', 'true')
       cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'true')
+      cy.getTestId("tally-settings-oi-toggle").should('have.attr', 'data-selected', 'true')
+      cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'true')
     })
   })
 
@@ -209,6 +226,7 @@ describe('Tally Settings', () => {
     ourConfig.setOperatorColorScheme("default")
     ourConfig.setStageColorScheme("default")
     ourConfig.setStageShowsPreview(true)
+    ourConfig.setOperatorShowsIdle(true)
 
     cy.getTestId(`tally-${name}`).contains(name).then(() => {
       socket.emit('tally.settings', name, "udp", ourConfig.toJson())
@@ -220,6 +238,7 @@ describe('Tally Settings', () => {
     cy.getTestId("tally-settings-oc").should('have.attr', 'data-value', 'default')
     cy.getTestId("tally-settings-sc").should('have.attr', 'data-value', 'default')
     cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'true')
+    cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'true')
     validateSliderValue("*[data-testid=tally-settings-ob]", 80)
     validateSliderValue("*[data-testid=tally-settings-sb]", 70).then(() => {
       // we change the settings from Hub without manual changes
@@ -228,11 +247,13 @@ describe('Tally Settings', () => {
       ourConfig.setOperatorColorScheme("yellow-pink")
       ourConfig.setStageColorScheme("yellow-pink")
       ourConfig.setStageShowsPreview(false)
+      ourConfig.setOperatorShowsIdle(false)
       socket.emit('tally.settings', name, "udp", ourConfig.toJson())
 
       cy.getTestId("tally-settings-oc").should('have.attr', 'data-value', 'yellow-pink')
       cy.getTestId("tally-settings-sc").should('have.attr', 'data-value', 'yellow-pink')
       cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'false')
+      cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'false')
       validateSliderValue("*[data-testid=tally-settings-ob]", 40)
       validateSliderValue("*[data-testid=tally-settings-sb]", 30)
     }).then(() => {
@@ -242,10 +263,12 @@ describe('Tally Settings', () => {
       cy.getTestId("tally-settings-oc-yellow-pink").click()
       cy.getTestId("tally-settings-sc-default").click()
       cy.getTestId("tally-settings-sp").click()
+      cy.getTestId("tally-settings-oi").click()
 
       cy.getTestId("tally-settings-oc").should('have.attr', 'data-value', 'yellow-pink')
       cy.getTestId("tally-settings-sc").should('have.attr', 'data-value', 'default')
       cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'true')
+      cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'true')
       validateSliderValue("*[data-testid=tally-settings-ob]", 99)
       validateSliderValue("*[data-testid=tally-settings-sb]", 98)
     }).then(() => {
@@ -255,11 +278,13 @@ describe('Tally Settings', () => {
       ourConfig.setOperatorColorScheme("default")
       ourConfig.setStageColorScheme("yellow-pink")
       ourConfig.setStageShowsPreview(false)
+      ourConfig.setOperatorShowsIdle(false)
       socket.emit('tally.settings', name, "udp", ourConfig.toJson())
 
       cy.getTestId("tally-settings-oc").should('have.attr', 'data-value', 'default')
       cy.getTestId("tally-settings-sc").should('have.attr', 'data-value', 'yellow-pink')
       cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'false')
+      cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'false')
       validateSliderValue("*[data-testid=tally-settings-ob]", 50)
       validateSliderValue("*[data-testid=tally-settings-sb]", 25)
     })
@@ -282,6 +307,8 @@ describe('Tally Settings', () => {
     cy.getTestId("tally-settings-sc").should('have.attr', 'data-value', 'default')
     cy.getTestId("tally-settings-sp-toggle").should('have.attr', 'data-selected', 'true')
     cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'true')
+    cy.getTestId("tally-settings-oi-toggle").should('have.attr', 'data-selected', 'true')
+    cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'true')
     cy.getTestId("tally-settings-ob-toggle").should('have.attr', 'data-selected', 'true')
     validateSliderValue("*[data-testid=tally-settings-ob]", 100)
     cy.getTestId("tally-settings-sb-toggle").should('have.attr', 'data-selected', 'true')
@@ -291,12 +318,14 @@ describe('Tally Settings', () => {
       defaultConfig.setOperatorColorScheme("yellow-pink")
       defaultConfig.setStageColorScheme("yellow-pink")
       defaultConfig.setStageShowsPreview(false)
+      defaultConfig.setOperatorShowsIdle(false)
       socket.emit('config.change.tallyconfig', defaultConfig.toJson())
       validateSliderValue("*[data-testid=tally-settings-ob]", 70)
       validateSliderValue("*[data-testid=tally-settings-sb]", 66)
       cy.getTestId("tally-settings-oc").should('have.attr', 'data-value', 'yellow-pink')
       cy.getTestId("tally-settings-sc").should('have.attr', 'data-value', 'yellow-pink')
       cy.getTestId("tally-settings-sp").should('have.attr', 'data-value', 'false')
+      cy.getTestId("tally-settings-oi").should('have.attr', 'data-value', 'false')
     })
   })
 
@@ -411,6 +440,23 @@ describe('Tally Settings', () => {
         cy.task("mixerProgPrev", {programs: ["2"], previews: ["1"]})
         cy.task('tallyLastCommand', name).then((lastCommand) => {
           expect(lastCommand).to.eq("O000/255/000 S000/000/000")
+        })
+      })
+    })
+
+    it("operator idle", () => {
+      cy.getTestId("tally-settings-oi-toggle")
+        .should('have.attr', 'data-selected', 'true')
+        .click()
+      cy.getTestId("tally-settings-oi").click()
+      cy.getTestId(`tally-settings-submit`).click()
+
+      cy.task('tallyLastCommand', name).then((lastCommand) => {
+        expect(lastCommand).to.eq("O255/000/000 S255/000/000")
+      }).then(() => {
+        cy.task("mixerProgPrev", {programs: [], previews: []})
+        cy.task('tallyLastCommand', name).then((lastCommand) => {
+          expect(lastCommand).to.eq("O000/000/000 S000/000/000")
         })
       })
     })

--- a/hub/src/components/TallySettings.tsx
+++ b/hub/src/components/TallySettings.tsx
@@ -44,6 +44,9 @@ function TallySettings({ tally, open, onClose }: TallySettingsProps) {
   // stageShowPreview
   const [sp, setSp] = useState<boolean>(settings ? settings.getStageShowsPreview() : undefined)
   const [isSpDefault, setSpDefault] = useState(settings && settings.getStageShowsPreview() === undefined)
+  // operatorShowIdle
+  const [oi, setOi] = useState<boolean>(settings ? settings.getOperatorShowsIdle() : undefined)
+  const [isOiDefault, setOiDefault] = useState(settings && settings.getOperatorShowsIdle() === undefined)
   useMemo(() => {
     // when default settings change
     if (defaultSettings) {
@@ -52,6 +55,7 @@ function TallySettings({ tally, open, onClose }: TallySettingsProps) {
       if (isOcDefault) { setOc(defaultSettings.getOperatorColorScheme()) }
       if (isScDefault) { setSc(defaultSettings.getStageColorScheme()) }
       if (isSpDefault) { setSp(defaultSettings.getStageShowsPreview()) }
+      if (isOiDefault) { setOi(defaultSettings.getOperatorShowsIdle()) }
     }
   }, [defaultSettings])
   useMemo(() => {
@@ -62,17 +66,20 @@ function TallySettings({ tally, open, onClose }: TallySettingsProps) {
       const newIsOcDefault = settings.getOperatorColorScheme() === undefined
       const newIsScDefault = settings.getStageColorScheme() === undefined
       const newIsSpDefault = settings.getStageShowsPreview() === undefined
+      const newIsOiDefault = settings.getOperatorShowsIdle() === undefined
       setObDefault(newIsObDefault)
       setSbDefault(newIsSbDefault)
       setOcDefault(newIsOcDefault)
       setScDefault(newIsScDefault)
       setSpDefault(newIsSpDefault)
+      setOiDefault(newIsOiDefault)
 
       if (!newIsObDefault) { setOb(settings.getOperatorLightBrightness()) }
       if (!newIsSbDefault) { setSb(settings.getStageLightBrightness()) }
       if (!newIsOcDefault) { setOc(settings.getOperatorColorScheme()) }
       if (!newIsScDefault) { setSc(settings.getStageColorScheme()) }
       if (!newIsSpDefault) { setSp(settings.getStageShowsPreview()) }
+      if (!newIsOiDefault) { setOi(settings.getOperatorShowsIdle()) }
     }
   }, [settings])
 
@@ -87,6 +94,7 @@ function TallySettings({ tally, open, onClose }: TallySettingsProps) {
     settings.setStageLightBrightness((!tally.hasStageLight || isSbDefault) ? undefined : sb)
     settings.setStageColorScheme((!tally.hasStageLight || isScDefault) ? undefined : sc)
     settings.setStageShowsPreview((!tally.hasStageLight || isSpDefault) ? undefined : sp)
+    settings.setOperatorShowsIdle((isOiDefault) ? undefined : oi)
     socket.emit('tally.settings', tally.name, tally.type, settings.toJson())
     onClose && onClose()
   }
@@ -128,6 +136,27 @@ function TallySettings({ tally, open, onClose }: TallySettingsProps) {
             value={oc}
             onChange={(value) => { setOc(value) }}
             disabled={isOcDefault}
+          />
+        </TallySettingsField>
+        <TallySettingsField
+          label="Operator Display"
+          isDefault={isOiDefault}
+          onChange={setOiDefault}
+          testId="tally-settings-oi"
+          className={classes.input}
+        >
+          <FormControlLabel
+            classes={{label: classes.checkboxLabel}}
+            control={<Checkbox
+              data-testid="tally-settings-oi"
+              data-value={isOiDefault ? defaultSettings.getOperatorShowsIdle() : oi}
+              checked={isOiDefault ? defaultSettings.getOperatorShowsIdle() : oi}
+              disabled={isOiDefault}
+              color="primary"
+              onChange={(e) => {setOi(e.target.checked)}}
+              size="small"
+            />}
+            label="Shows Idle State"
           />
         </TallySettingsField>
         { tally.hasStageLight && (<>

--- a/hub/src/components/config/TallySettings.tsx
+++ b/hub/src/components/config/TallySettings.tsx
@@ -32,6 +32,7 @@ function TallySettings() {
   const [operatorColorScheme, setOperatorColorScheme] = useState<ColorSchemeId>(undefined)
   const [stageColorScheme, setStageColorScheme] = useState<ColorSchemeId>(undefined)
   const [stageShowsPreview, setStageShowsPreview] = useState<boolean>(undefined)
+  const [operatorShowsIdle, setOperatorShowsIdle] = useState<boolean>(undefined)
   useMemo(() => {
     // called when setting changed
     setOperatorBrightness(settings?.getOperatorLightBrightness())
@@ -39,7 +40,7 @@ function TallySettings() {
     setOperatorColorScheme(settings?.getOperatorColorScheme())
     setStageColorScheme(settings?.getStageColorScheme())
     setStageShowsPreview(settings?.getStageShowsPreview())
-    
+    setOperatorShowsIdle(settings?.getOperatorShowsIdle())
   }, [settings])
 
   const classes = useStyle()
@@ -52,6 +53,7 @@ function TallySettings() {
     operatorColorScheme !== undefined && settings.setOperatorColorScheme(operatorColorScheme)
     stageColorScheme !== undefined && settings.setStageColorScheme(stageColorScheme)
     stageShowsPreview !== undefined && settings.setStageShowsPreview(stageShowsPreview)
+    operatorShowsIdle !== undefined && settings.setOperatorShowsIdle(operatorShowsIdle)
 
     socket.emit('config.change.tallyconfig', settings.toJson())
   }
@@ -74,6 +76,21 @@ function TallySettings() {
           testId="tally-defaults-oc"
           value={operatorColorScheme}
           onChange={(value) => {setOperatorColorScheme(value)}}
+        />
+      </div>
+      <div className={classes.input}>
+        <Typography paragraph variant="h6">Operator Display</Typography>
+        <FormControlLabel
+          classes={{label: classes.checkboxLabel}}
+          control={<Checkbox
+            data-testid="tally-defaults-oi"
+            data-value={operatorShowsIdle}
+            checked={operatorShowsIdle}
+            color="primary"
+            onChange={(e) => {setOperatorShowsIdle(e.target.checked)}}
+            size="small"
+          />}
+          label="Shows Idle State"
         />
       </div>
       <div className={classes.input}>

--- a/hub/src/tally/CommandCreator.spec.ts
+++ b/hub/src/tally/CommandCreator.spec.ts
@@ -53,6 +53,9 @@ describe("stageLightBrightness()", () => {
         test('for PROGRAM', () => {
             expect(CommandCreator.createStateCommand(tally, ["channel"], [], defaultConfig)).toEqual("O255/000/000 S128/000/000")
         })
+        test('for RELEASE', () => {
+            expect(CommandCreator.createStateCommand(tally, [], [], defaultConfig)).toEqual("O000/001/000 S000/000/000")
+        })
     })
     describe('it can be overridden by a tally configuration', () => {
         const tally = new UdpTally("test", "channel")
@@ -166,6 +169,31 @@ describe("stageShowPreview()", () => {
         })
         test('for PROGRAM', () => {
             expect(CommandCreator.createStateCommand(tally, ["channel"], [], defaultConfig)).toEqual("O255/000/000 S255/000/000")
+        })
+    })
+})
+describe("operatorShowsIdle()", () => {
+    describe('it uses the default', () => {
+        const defaultConfig = new DefaultTallyConfiguration()
+        defaultConfig.setOperatorShowsIdle(false)
+        const tally = new UdpTally("test", "channel")
+        test('for PROGRAM', () => {
+            expect(CommandCreator.createStateCommand(tally, ["channel"], [], defaultConfig)).toEqual("O255/000/000 S255/000/000")
+        })
+        test('for RELEASE', () => {
+            expect(CommandCreator.createStateCommand(tally, [], [], defaultConfig)).toEqual("O000/000/000 S000/000/000")
+        })
+    })
+    describe('it can be overridden by a tally configuration', () => {
+        const defaultConfig = new DefaultTallyConfiguration()
+        defaultConfig.setOperatorShowsIdle(true)
+        const tally = new UdpTally("test", "channel")
+        tally.configuration.setOperatorShowsIdle(false)
+        test('for PROGRAM', () => {
+            expect(CommandCreator.createStateCommand(tally, ["channel"], [], defaultConfig)).toEqual("O255/000/000 S255/000/000")
+        })
+        test('for RELEASE', () => {
+            expect(CommandCreator.createStateCommand(tally, [], [], defaultConfig)).toEqual("O000/000/000 S000/000/000")
         })
     })
 })

--- a/hub/src/tally/CommandCreator.ts
+++ b/hub/src/tally/CommandCreator.ts
@@ -43,7 +43,8 @@ class CommandCreator {
       const showPreview = tally.configuration.getStageShowsPreview() === undefined ? defaultConfiguration.getStageShowsPreview() : tally.configuration.getStageShowsPreview()
       stColor = showPreview ? stColorScheme.preview : Black
     } else if (state === "release") {
-      opColor = opColorScheme.idle
+      const showIdle = tally.configuration.getOperatorShowsIdle() === undefined ? defaultConfiguration.getOperatorShowsIdle() : tally.configuration.getOperatorShowsIdle()
+      opColor = showIdle ? opColorScheme.idle : Black
       stColor = Black
     } else if (state === "unknown") {
       opColor = opColorScheme.unknown

--- a/hub/src/tally/TallyConfiguration.spec.ts
+++ b/hub/src/tally/TallyConfiguration.spec.ts
@@ -9,6 +9,7 @@ describe('DefaultTallyConfiguration', () => {
     expect(config.getStageColorScheme()).toEqual("default")
     expect(config.getOperatorColorScheme()).toEqual("default")
     expect(config.getStageShowsPreview()).toEqual(true)
+    expect(config.getOperatorShowsIdle()).toEqual(true)
   })
 
   describe('getStageLightBrightness', () => {
@@ -60,6 +61,7 @@ describe('DefaultTallyConfiguration', () => {
         conf.setOperatorColorScheme("yellow-pink")
         conf.setStageColorScheme("yellow-pink")
         conf.setStageShowsPreview(false)
+        conf.setOperatorShowsIdle(false)
 
         const loadedConf = new DefaultTallyConfiguration()
         loadedConf.fromJson(conf.toJson())
@@ -69,17 +71,20 @@ describe('DefaultTallyConfiguration', () => {
         expect(loadedConf.getOperatorColorScheme()).toEqual("yellow-pink")
         expect(loadedConf.getOperatorColorScheme()).toEqual("yellow-pink")
         expect(loadedConf.getStageShowsPreview()).toEqual(false)
+        expect(loadedConf.getOperatorShowsIdle()).toEqual(false)
     })
     it("handles falsy values correctly", () => {
         const conf = new DefaultTallyConfiguration()
         conf.setStageLightBrightness(0)
         conf.setStageShowsPreview(false)
+        conf.setOperatorShowsIdle(false)
 
         const loadedConf = new DefaultTallyConfiguration()
         loadedConf.fromJson(conf.toJson())
         
         expect(loadedConf.getStageLightBrightness()).toBe(0)
         expect(loadedConf.getStageShowsPreview()).toBe(false)
+        expect(loadedConf.getOperatorShowsIdle()).toBe(false)
     })
   })
 
@@ -106,6 +111,7 @@ describe('TallyConfiguration', () => {
     expect(config.getStageColorScheme()).toBeUndefined()
     expect(config.getOperatorColorScheme()).toBeUndefined()
     expect(config.getStageShowsPreview()).toBeUndefined()
+    expect(config.getOperatorShowsIdle()).toBeUndefined()
   })
 
   describe('getStageLightBrightness', () => {
@@ -157,6 +163,7 @@ describe('TallyConfiguration', () => {
         conf.setStageColorScheme("yellow-pink")
         conf.setOperatorColorScheme("yellow-pink")
         conf.setStageShowsPreview(false)
+        conf.setOperatorShowsIdle(false)
 
         const loadedConf = new TallyConfiguration()
         loadedConf.fromJson(conf.toJson())
@@ -166,17 +173,20 @@ describe('TallyConfiguration', () => {
         expect(loadedConf.getStageColorScheme()).toEqual("yellow-pink")
         expect(loadedConf.getOperatorColorScheme()).toEqual("yellow-pink")
         expect(loadedConf.getStageShowsPreview()).toEqual(false)
+        expect(loadedConf.getOperatorShowsIdle()).toEqual(false)
     })
     it("handles falsy values correctly", () => {
         const conf = new TallyConfiguration()
         conf.setStageLightBrightness(0)
         conf.setStageShowsPreview(false)
+        conf.setOperatorShowsIdle(false)
 
         const loadedConf = new TallyConfiguration()
         loadedConf.fromJson(conf.toJson())
         
         expect(loadedConf.getStageLightBrightness()).toBe(0)
         expect(loadedConf.getStageShowsPreview()).toBe(false)
+        expect(loadedConf.getOperatorShowsIdle()).toBe(false)
     })
     it("loads undefined correctly", () => {
         const conf = new TallyConfiguration()
@@ -185,6 +195,7 @@ describe('TallyConfiguration', () => {
         conf.setStageColorScheme(undefined)
         conf.setOperatorColorScheme(undefined)
         conf.setStageShowsPreview(undefined)
+        conf.setOperatorShowsIdle(undefined)
 
         const loadedConf = new TallyConfiguration()
         loadedConf.fromJson(conf.toJson())
@@ -194,6 +205,7 @@ describe('TallyConfiguration', () => {
         expect(loadedConf.getStageColorScheme()).toBeUndefined()
         expect(loadedConf.getOperatorColorScheme()).toBeUndefined()
         expect(loadedConf.getStageShowsPreview()).toBeUndefined()
+        expect(loadedConf.getOperatorShowsIdle()).toBeUndefined()
     })
   })
 })

--- a/hub/src/tally/TallyConfiguration.ts
+++ b/hub/src/tally/TallyConfiguration.ts
@@ -5,7 +5,8 @@ export type TallyConfigurationObjectType = {
   opBrightness?: number
   stColor?: ColorSchemeId
   opColor?: ColorSchemeId
-  stPreview: boolean
+  stPreview?: boolean
+  opIdle?: boolean
 }
 
 /**
@@ -17,6 +18,7 @@ export class DefaultTallyConfiguration {
   private _operatorLightBrightness?: number = DefaultTallyConfiguration.defaultBrightness
   private _operatorColorScheme: ColorSchemeId = DefaultTallyConfiguration.defaultColorScheme
   private _stageShowsPreview: boolean = true
+  private _operatorShowsIdle: boolean = true
 
   static readonly defaultColorScheme : ColorSchemeId = DefaultColorScheme.id
   static readonly minOperatorLightBrightness = 20
@@ -51,6 +53,9 @@ export class DefaultTallyConfiguration {
   getStageShowsPreview() { return this._stageShowsPreview }
   setStageShowsPreview(shouldItShow: boolean) { this._stageShowsPreview = shouldItShow }
 
+  getOperatorShowsIdle() { return this._operatorShowsIdle}
+  setOperatorShowsIdle(shouldItShow: boolean) { this._operatorShowsIdle = shouldItShow }
+
   toJson() : TallyConfigurationObjectType {
     return {
       stBrightness: this._stageLightBrightness,
@@ -58,6 +63,7 @@ export class DefaultTallyConfiguration {
       stColor: this._stageColorScheme,
       opColor: this._operatorColorScheme,
       stPreview: this._stageShowsPreview,
+      opIdle: this._operatorShowsIdle,
     }
   }
   fromJson(valueObject: TallyConfigurationObjectType) {
@@ -66,6 +72,7 @@ export class DefaultTallyConfiguration {
     valueObject.stColor !== undefined && this.setStageColorScheme(valueObject.stColor)
     valueObject.opColor !== undefined && this.setOperatorColorScheme(valueObject.opColor)
     valueObject.stPreview !== undefined && this.setStageShowsPreview(valueObject.stPreview)
+    valueObject.opIdle !== undefined && this.setOperatorShowsIdle(valueObject.opIdle)
   }
 
   clone(): DefaultTallyConfiguration {
@@ -84,6 +91,7 @@ export class TallyConfiguration {
   private _stageColorScheme: ColorSchemeId = undefined
   private _operatorColorScheme: ColorSchemeId = undefined
   private _stageShowsPreview: boolean = undefined
+  private _operatorShowsIdle: boolean = undefined
 
   getStageLightBrightness() { return this._stageLightBrightness }
   setStageLightBrightness(value: number) { 
@@ -116,6 +124,9 @@ export class TallyConfiguration {
   getStageShowsPreview() { return this._stageShowsPreview }
   setStageShowsPreview(shouldItShow: boolean) { this._stageShowsPreview = shouldItShow }
 
+  getOperatorShowsIdle() { return this._operatorShowsIdle}
+  setOperatorShowsIdle(shouldItShow: boolean) { this._operatorShowsIdle = shouldItShow }
+
   toJson() : TallyConfigurationObjectType {
     return {
       stBrightness: this._stageLightBrightness,
@@ -123,6 +134,7 @@ export class TallyConfiguration {
       stColor: this._stageColorScheme,
       opColor: this._operatorColorScheme,
       stPreview: this._stageShowsPreview,
+      opIdle: this._operatorShowsIdle,
     }
   }
   fromJson(valueObject: TallyConfigurationObjectType) {
@@ -131,6 +143,7 @@ export class TallyConfiguration {
     this.setStageColorScheme(valueObject.stColor)
     this.setOperatorColorScheme(valueObject.opColor)
     this.setStageShowsPreview(valueObject.stPreview)
+    this.setOperatorShowsIdle(valueObject.opIdle)
   }
 }
 


### PR DESCRIPTION
This should avoid confusion when the operator light is dimmed,
and it shows how much you trust the tally to work correctly. Thank you! :D

Relates: #50