### PR TITLE
Enhance support for embedded scenes in OBS

### DIFF
--- a/hub/src/mixer/obs/ObsConnector.ts
+++ b/hub/src/mixer/obs/ObsConnector.ts
@@ -39,6 +39,18 @@ class ObsConnector implements Connector{
             // console.debug('ScenesChanged', data)
             this.updateScenes()
         })
+        this.obs.on('SceneItemRemoved', data => {
+            // console.debug('ScenesChanged', data)
+            this.updateScenes()
+        })
+        this.obs.on('SceneItemAdded', data => {
+            // console.debug('ScenesChanged', data)
+            this.updateScenes()
+        })
+        this.obs.on('SceneItemVisibilityChanged', data => {
+            // console.debug('ScenesChanged', data)
+            this.updateScenes()
+        })
         this.obs.on('SceneCollectionChanged', data => {
             // console.debug('SceneCollectionChanged', data)
             this.updateScenes()
@@ -166,7 +178,7 @@ class ObsConnector implements Connector{
     private updateEmbeddedScenes(scenes: OBSWebSocket.Scene[]) {
         this.embeddedScenes = {}
         scenes.forEach(scene => {
-            this.embeddedScenes[scene.name] = scene.sources.filter(source => source.type === "scene").map(source => source.name)
+            this.embeddedScenes[scene.name] = scene.sources.filter(source => source.type === "scene" && source.render === true).map(source => source.name)
         })
     }
     private notifyProgramChanged(scenes: string[]) {


### PR DESCRIPTION
Currently, embedded scenes in OBS are only properly detected at start-up or when creating a new scene. The action of adding a new embedded in scene is not caught and therefore the internal map not updated. Also, an properly detected embedded scene will always trigger a tally indication, regardless of its actual visibility in the parent scene.

This edit changes the behaviour in both cases, added and removed embedded scenes should now be detected and an invisible detected scene will not trigger a tally indication.