### PR TITLE
Reconnect to vmix after connection has closed

### DIFF
--- a/hub/src/mixer/vmix/VmixConnector.ts
+++ b/hub/src/mixer/vmix/VmixConnector.ts
@@ -95,10 +95,8 @@ class VmixConnector implements Connector {
                 this.intervalHandle = undefined;
             }
 
-            if (hadError) {
-                console.debug("Connection to vMix is reconnected after an error")
-                reconnectClient()
-            }
+            console.debug("Connection to vMix is reconnected after a discronnect")
+            reconnectClient()
         })
 
     }


### PR DESCRIPTION
Currently there is a bug. When you close VMix and reopen it, the hub doesnt reconnect to vmix.

Here I made the fix for it, so it reconnects to vMix again.
